### PR TITLE
Require Idris 0.99.1 to build

### DIFF
--- a/descncrunch.ipkg
+++ b/descncrunch.ipkg
@@ -3,7 +3,8 @@ package descncrunch
 sourcedir = src
 pkgs = pruviloj
 
-modules = Descriptions.Core
+modules = Descriptions.Automation
+        , Descriptions.Core
         , Descriptions.DecEq
         , Descriptions.Eq
         , Descriptions.Examples

--- a/src/Descriptions/Automation.idr
+++ b/src/Descriptions/Automation.idr
@@ -4,6 +4,8 @@ import Language.Reflection.Utils
 import Descriptions.Core
 import Pruviloj
 
+%language ElabReflection
+
 ctorTags : TTName -> Elab (List TTName)
 ctorTags datatype =
   do ctors <- constructors <$> lookupDatatypeExact datatype
@@ -36,7 +38,7 @@ getIndices tyN tcArgs tm =
      -- Sanity check
      case op of
        Var n => if n == tyN
-                  then return ()
+                  then pure ()
                   else fail [TextPart "Wrong datatype: ", NamePart n]
        other => fail [TextPart "Not a datatype application"]
      getArgs args tcArgs

--- a/src/Descriptions/Examples.idr
+++ b/src/Descriptions/Examples.idr
@@ -6,6 +6,8 @@ import Descriptions.DecEq
 import Descriptions.Functor
 import Control.Isomorphism
 
+%language ElabReflection
+
 ---- Examples
 VecCtors : CtorEnum
 VecCtors = [ `{Vect.Nil} , `{Vect.(::)} ]


### PR DESCRIPTION
Some things that @david-christiansen and I noticed when trying to build `desc-n-crunch` on Idris 0.99.1:

* `Descriptions.Automation` isn't in the `.ipkg` file. I don't know if this was intended to be internal or not, but I opted to add it explicitly.
* You need `%language ElabReflection` in some files.

That last bit explicitly requires Idris 0.99.1, I believe, so I thought I'd propose this first to see if anyone wants to keep building this on old Idrises.